### PR TITLE
Update Swift Debugger project link to current active repository

### DIFF
--- a/lldb/index.md
+++ b/lldb/index.md
@@ -4,7 +4,7 @@ title: REPL and Debugger
 ---
 
 The Swift.org community makes use of the
-[LLDB debugger](https://github.com/apple/swift-lldb) to provide a
+[LLDB debugger](https://github.com/apple/llvm-project/tree/next/lldb) to provide a
 rich REPL as well as the debugging environment for the Swift Language.
 Swift is tightly coupled to the version of the  Swift compiler embedded in the
 debugger.  Tight integration of compiler and debugger enables accurate


### PR DESCRIPTION
Currently if you click through the link on this page it takes you to the archived swift-lldb repository.

<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

### Motivation:

<!-- _[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_ -->

### Modifications:

<!-- _[Describe the modifications you've done.]_ -->

### Result:

<!-- _[After your change, what will change.]_ -->
